### PR TITLE
replace node iteration with treewalker api

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,18 +1,10 @@
-var elements = document.getElementsByTagName('*');
+var node;
+var walk = document.createTreeWalker(document.body,NodeFilter.SHOW_TEXT,null,false);
 
-for (var i = 0; i < elements.length; i++) {
-    var element = elements[i];
-
-    for (var j = 0; j < element.childNodes.length; j++) {
-        var node = element.childNodes[j];
-
-        if (node.nodeType === 3) {
-            var text = node.nodeValue;
-            var replacedText = text.replace(/Liviu Dragnea/gi, 'Infractorul condamnat definitiv Liviu Dragnea');
-
-            if (replacedText !== text) {
-                element.replaceChild(document.createTextNode(replacedText), node);
-            }
-        }
-    }
+while(node=walk.nextNode()) {
+    var text = node.nodeValue;
+    if (text.search(/Liviu Dragnea/gi) >= 0)
+    {   
+        node.nodeValue = text.replace(/Liviu Dragnea/gi, 'Infractorul condamnat definitiv Liviu Dragnea');
+    }    
 }


### PR DESCRIPTION
I've refactored the DOM traversal to use the [TreeWalker](https://developer.mozilla.org/en/docs/Web/API/TreeWalker) api. 

Seeing ~ x6 performance improvements on https://en.wikipedia.org/wiki/Liviu_Dragnea

Old version takes  ~20ms, new version ~3ms 

I've used [performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) to measure the performance over a couple of page refreshes 

```
var t0 = performance.now();
// code
var t1 = performance.now();
console.log((t1 - t0) + " milliseconds.")
```
