### PR TITLE
whitespace between 'Liviu' and 'Dragnea'

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -5,6 +5,6 @@ while(node=walk.nextNode()) {
     var text = node.nodeValue;
     if (text.search(/Liviu Dragnea/gi) >= 0)
     {   
-        node.nodeValue = text.replace(/Liviu Dragnea/gi, 'Infractorul condamnat definitiv Liviu Dragnea');
+        node.nodeValue = text.replace(/Liviu\s+Dragnea/gi, 'Infractorul condamnat definitiv Liviu Dragnea');
     }    
 }


### PR DESCRIPTION
Before, "Liviu  Dragnea" (two space characters) wouldn't have been replaced.