### PR TITLE
add support for dynamic updates

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,10 +1,31 @@
-var node;
-var walk = document.createTreeWalker(document.body,NodeFilter.SHOW_TEXT,null,false);
+var regex = /Liviu\s+(Nicolae)?\s*Dragnea/gi 
 
-while(node=walk.nextNode()) {
+function dragnea(node) {
+    var walk = document.createTreeWalker(node,NodeFilter.SHOW_TEXT,null,false);
+    var node;
+
+    while(node=walk.nextNode()) {
     var text = node.nodeValue;
-    if (text.search(/Liviu Dragnea/gi) >= 0)
-    {   
-        node.nodeValue = text.replace(/Liviu\s+Dragnea/gi, 'Infractorul condamnat definitiv Liviu Dragnea');
-    }    
+    if (text.search(regex) >= 0) {   
+        node.nodeValue = text.replace(regex, 'Infractorul condamnat definitiv Liviu Dragnea');
+        }    
+    }
 }
+
+
+
+var observer = new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    if (mutation.addedNodes.length) {
+      for ( var addedNode of mutation.addedNodes) {
+        dragnea(addedNode);
+      }
+    }
+  })
+});
+
+
+// because facebook
+observer.observe(document.body, { childList: true,  subtree: true });
+
+dragnea(document.body);


### PR DESCRIPTION
This PR adds support for dynamic page updates  ( think infinite facebook scrolling).  

Now when you scroll through your news feed or have a chat with someone the autocorrect kicks in.  

Also:
- removed the unnecessary regex duplication
- tweaked regex to support the full name (check the wikipedia page)
